### PR TITLE
added correct config file names to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,11 @@ node_modules
 
 /.idea/
 
-config.dev.yaml
+config.development.yaml
+config.production.yaml
+config.staging.yaml
+config.users.yaml
+config.yaml
 
 .DS_Store
 


### PR DESCRIPTION
The wrong file name for the development config file has been used in `.gitignore`.